### PR TITLE
Downloading comment attachments

### DIFF
--- a/studentwork.py
+++ b/studentwork.py
@@ -59,6 +59,8 @@ SUBMISSION_PERCENTILES = {
     "Good": 0.95       # 95th percentile
 }
 
+DOWNLOAD_COMMENT_ATTACHMENTS = True
+
 # --- END CONFIGURATION ---
 
 
@@ -67,7 +69,6 @@ def sanitize_filename(name):
     Removes characters from a string that are invalid for file names.
     """
     return "".join(c for c in name if c.isalnum() or c in (' ', '.', '_')).rstrip()
-
 
 def download_submission_examples(canvas, course_id, assignment_names):
     """
@@ -208,15 +209,16 @@ def download_submission_examples(canvas, course_id, assignment_names):
                                 comment_file.write("="*50 + "\n\n")
                                 
                                 for i, comment in enumerate(submission.submission_comments, 1):
-                                    attachment = comment['attachments'][0]  # Download the first attachment
-                                    original_filename = attachment['filename']
-                                    file_extension = os.path.splitext(original_filename)[1]
-                                    comment_attachment_file = f"{clean_assignment_name}_{percent_score}_comment{i}{file_extension}"
-                                    comment_attachment_path = os.path.join(quantile_dir, comment_attachment_file)
-                                    print(f"  -> Downloading '{comment_attachment_file}' to {quantile_label} folder...")
-                                    attachment = File(requester, attachment)
-                                    attachment.download(comment_attachment_path)
-                                    print(f"     Success! Saved to '{file_path}'")
+                                    if DOWNLOAD_COMMENT_ATTACHMENTS:
+                                        attachment = comment['attachments'][0]  # Download the first attachment
+                                        original_filename = attachment['filename']
+                                        file_extension = os.path.splitext(original_filename)[1]
+                                        comment_attachment_file = f"{clean_assignment_name}_{percent_score}_comment{i}{file_extension}"
+                                        comment_attachment_path = os.path.join(quantile_dir, comment_attachment_file)
+                                        print(f"  -> Downloading '{comment_attachment_file}' to {quantile_label} folder...")
+                                        attachment = File(requester, attachment)
+                                        attachment.download(comment_attachment_path)
+                                        print(f"     Success! Saved to '{comment_attachment_path}'")
 
                                     comment_file.write(f"Comment {i}:\n")
                                     comment_file.write(f"Author: {comment.get('author_name', 'Unknown')}\n")
@@ -238,15 +240,16 @@ def download_submission_examples(canvas, course_id, assignment_names):
                                         comment_file.write("="*50 + "\n\n")
                                         
                                         for i, comment in enumerate(comments.submission_comments, 1):
-                                            attachment = comment['attachments'][0]  # Download the first attachment
-                                            original_filename = attachment['filename']
-                                            file_extension = os.path.splitext(original_filename)[1]
-                                            comment_attachment_file = f"{clean_assignment_name}_{percent_score}_comment{i}{file_extension}"
-                                            comment_attachment_path = os.path.join(quantile_dir, comment_attachment_file)
-                                            print(f"  -> Downloading '{comment_attachment_file}' to {quantile_label} folder...")
-                                            attachment = File(requester, attachment)
-                                            attachment.download(comment_attachment_path)
-                                            print(f"     Success! Saved to '{file_path}'")
+                                            if DOWNLOAD_COMMENT_ATTACHMENTS:
+                                                attachment = comment['attachments'][0]  # Download the first attachment
+                                                original_filename = attachment['filename']
+                                                file_extension = os.path.splitext(original_filename)[1]
+                                                comment_attachment_file = f"{clean_assignment_name}_{percent_score}_comment{i}{file_extension}"
+                                                comment_attachment_path = os.path.join(quantile_dir, comment_attachment_file)
+                                                print(f"  -> Downloading '{comment_attachment_file}' to {quantile_label} folder...")
+                                                attachment = File(requester, attachment)
+                                                attachment.download(comment_attachment_path)
+                                                print(f"     Success! Saved to '{comment_attachment_path}'")
                                             
                                             comment_file.write(f"Comment {i}:\n")
                                             comment_file.write(f"Author: {comment.get('author_name', 'Unknown')}\n")

--- a/studentwork.py
+++ b/studentwork.py
@@ -209,7 +209,12 @@ def download_submission_examples(canvas, course_id, assignment_names):
                                 comment_file.write("="*50 + "\n\n")
                                 
                                 for i, comment in enumerate(submission.submission_comments, 1):
-                                    if DOWNLOAD_COMMENT_ATTACHMENTS:
+                                    comment_file.write(f"Comment {i}:\n")
+                                    comment_file.write(f"Author: {comment.get('author_name', 'Unknown')}\n")
+                                    comment_file.write(f"Date: {comment.get('created_at', 'Unknown')}\n")
+                                    comment_file.write(f"Comment: {comment.get('comment', 'No comment text')}\n")
+                                    comment_file.write("-" * 30 + "\n\n")
+                                    if DOWNLOAD_COMMENT_ATTACHMENTS and "attachments" in comment:
                                         attachment = comment['attachments'][0]  # Download the first attachment
                                         original_filename = attachment['filename']
                                         file_extension = os.path.splitext(original_filename)[1]
@@ -220,11 +225,6 @@ def download_submission_examples(canvas, course_id, assignment_names):
                                         attachment.download(comment_attachment_path)
                                         print(f"     Success! Saved to '{comment_attachment_path}'")
 
-                                    comment_file.write(f"Comment {i}:\n")
-                                    comment_file.write(f"Author: {comment.get('author_name', 'Unknown')}\n")
-                                    comment_file.write(f"Date: {comment.get('created_at', 'Unknown')}\n")
-                                    comment_file.write(f"Comment: {comment.get('comment', 'No comment text')}\n")
-                                    comment_file.write("-" * 30 + "\n\n")
                             
                             print(f"     Comments saved to '{comment_file_path}'")
                         else:
@@ -240,7 +240,12 @@ def download_submission_examples(canvas, course_id, assignment_names):
                                         comment_file.write("="*50 + "\n\n")
                                         
                                         for i, comment in enumerate(comments.submission_comments, 1):
-                                            if DOWNLOAD_COMMENT_ATTACHMENTS:
+                                            comment_file.write(f"Comment {i}:\n")
+                                            comment_file.write(f"Author: {comment.get('author_name', 'Unknown')}\n")
+                                            comment_file.write(f"Date: {comment.get('created_at', 'Unknown')}\n")
+                                            comment_file.write(f"Comment: {comment.get('comment', 'No comment text')}\n")
+                                            comment_file.write("-" * 30 + "\n\n")
+                                            if DOWNLOAD_COMMENT_ATTACHMENTS and 'attachments' in comment:
                                                 attachment = comment['attachments'][0]  # Download the first attachment
                                                 original_filename = attachment['filename']
                                                 file_extension = os.path.splitext(original_filename)[1]
@@ -250,12 +255,6 @@ def download_submission_examples(canvas, course_id, assignment_names):
                                                 attachment = File(requester, attachment)
                                                 attachment.download(comment_attachment_path)
                                                 print(f"     Success! Saved to '{comment_attachment_path}'")
-                                            
-                                            comment_file.write(f"Comment {i}:\n")
-                                            comment_file.write(f"Author: {comment.get('author_name', 'Unknown')}\n")
-                                            comment_file.write(f"Date: {comment.get('created_at', 'Unknown')}\n")
-                                            comment_file.write(f"Comment: {comment.get('comment', 'No comment text')}\n")
-                                            comment_file.write("-" * 30 + "\n\n")
                                     
                                     print(f"     Comments saved to '{comment_file_path}'")
                                 else:

--- a/studentwork.py
+++ b/studentwork.py
@@ -33,8 +33,6 @@ from canvasapi.requester import Requester
 from canvasapi.file import File
 from canvasapi.exceptions import CanvasException, ResourceDoesNotExist, Unauthorized
 
-import pdb
-
 # --- START CONFIGURATION ---
 
 # Your Canvas instance URL


### PR DESCRIPTION
My grading workflow has my graders annotate the students' submission PDF with for marking. These are then bulk uploaded into canvas, which causes them to appear at attachments to a grader comment. I've added the ability to download these files as well. This lets me put the grader markings in the course displays.